### PR TITLE
fix: removed cascade deletion of rides.

### DIFF
--- a/src/main/java/com/api/bigu/models/Ride.java
+++ b/src/main/java/com/api/bigu/models/Ride.java
@@ -23,10 +23,10 @@ public class Ride {
     @Column(name = "driver_id")
     private Integer driverId;
 
-    @ManyToMany(cascade = CascadeType.ALL)
+    @ManyToMany
     private List<User> members;
 
-    @ManyToMany(cascade = CascadeType.ALL)
+    @ManyToMany
     private List<Candidate> candidates;
 
     @ManyToOne

--- a/src/main/java/com/api/bigu/user/User.java
+++ b/src/main/java/com/api/bigu/user/User.java
@@ -59,15 +59,15 @@ public class User implements UserDetails {
     @Enumerated(EnumType.STRING)
     private Role role;
 
-    @OneToMany(mappedBy = "userId", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "userId")
     @Column(name = "addresses")
     private Map<String, Address> addresses;
 
-    @OneToMany(mappedBy = "userId", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "userId")
     @Column(name = "cars")
     private Map<String, Car> cars;
 
-    @ManyToMany(mappedBy = "members", cascade = CascadeType.ALL)
+    @ManyToMany(mappedBy = "members")
     @JsonIgnore
     private List<Ride> rides;
 


### PR DESCRIPTION
# Problem
What seems to be happening is that all rides were deleted when one single ride was deleted.

# Solution
A possible fix is to remove the cascade annotations we had on the Ride and User classes. 

# Test made
In this test, this issue is not happening anymore. Basically, I'm creating a user, a car, two addresses and three rides, then I remove one of them and see if the others are still there. 
[Test requests.txt](https://github.com/biguapp/bigu-backend/files/12327854/Test.requests.txt)